### PR TITLE
Allow safe attributes for list

### DIFF
--- a/Web.HtmlSanitizer/HtmlSanitizer.cs
+++ b/Web.HtmlSanitizer/HtmlSanitizer.cs
@@ -446,8 +446,12 @@ namespace Vereyon.Web
             sanitizer.Tag("div").NoAttributes(SanitizerOperation.FlattenTag);
             sanitizer.Tag("span").RemoveEmpty();
             sanitizer.Tag("ul");
-            sanitizer.Tag("ol");
-            sanitizer.Tag("li");
+            sanitizer.Tag("ol")
+                .AllowAttributes("start")
+                .AllowAttributes("type")
+                .AllowAttributes("reversed");
+            sanitizer.Tag("li")
+                .AllowAttributes("value");
             sanitizer.Tag("a").SetAttribute("target", "_blank")
                 .SetAttribute("rel", "nofollow")
                 .CheckAttribute("href", HtmlSanitizerCheckType.Url)


### PR DESCRIPTION
"start", "type" and "reversed" are perfectly fine attributes for OrderedList
So are "value" for list item.
Also, "start" and "type" attribute required for being able to correct rendering of markdown