### PR TITLE
Add tel to list of allowed schemes

### DIFF
--- a/Web.HtmlSanitizer/HtmlSanitizer.cs
+++ b/Web.HtmlSanitizer/HtmlSanitizer.cs
@@ -79,7 +79,7 @@ namespace Vereyon.Web
         /// <summary>
         /// Collection of the allowed URI schemes.
         /// </summary>
-        public static IEnumerable<string> AllowedUriSchemes = new string[] { "http", "https", "mailto" };
+        public static IEnumerable<string> AllowedUriSchemes = new string[] { "http", "https", "mailto", "tel" };
 
         /// <summary>
         /// Checks if the passed HTML attribute contains a valid URL.


### PR DESCRIPTION
tel scheme is used to mark phones numbers according to https://tools.ietf.org/html/rfc3966

I have reviewed security considerations of according RFC https://tools.ietf.org/html/rfc3966#section-11 and it seems like a safe change.

Another solution is to allow configuration of allowed schemas. Which one do you prefer?