### PR TITLE
Add element sanitizers

### DIFF
--- a/Web.HtmlSanitizer.Tests/ElementSanitizationTests.cs
+++ b/Web.HtmlSanitizer.Tests/ElementSanitizationTests.cs
@@ -1,0 +1,61 @@
+﻿using HtmlAgilityPack;
+using System;
+using Xunit;
+
+namespace Vereyon.Web
+{
+    public class ElementSanitizationTests
+    {
+        [Fact]
+        public void WrapElement()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.Tag("p");
+            sanitizer.Tag("span").Sanitize(new CustomSanitizer(element =>
+            {
+                var wrapper = element.OwnerDocument.CreateElement("div");
+                element.ParentNode.ReplaceChild(wrapper, element);
+                wrapper.AppendChild(element);
+                return SanitizerOperation.DoNothing;
+            }));
+
+            var input = "<p><span>Text</span></p>";
+            var expected = "<p><div><span>Text</span></div></p>";
+            var result = sanitizer.Sanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void RemoveElementBasedOnContent()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.Tag("span").Sanitize(new CustomSanitizer(element =>
+            {
+                return element.InnerText == "remove me"
+                    ? SanitizerOperation.RemoveTag
+                    : SanitizerOperation.DoNothing;
+            }));
+
+            var input = "<span>keep me</span><span>remove me</span>";
+            var expected = "<span>keep me</span>";
+            var result = sanitizer.Sanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+
+        class CustomSanitizer : IHtmlElementSanitizer
+        {
+            private readonly Func<HtmlNode, SanitizerOperation> sanitize;
+
+            public CustomSanitizer(Func<HtmlNode, SanitizerOperation> sanitize)
+            {
+                this.sanitize = sanitize;
+            }
+
+            public SanitizerOperation SanitizeElement(HtmlNode element, HtmlSanitizerTagRule tagRule)
+            {
+                return sanitize(element);
+            }
+        }
+    }
+}

--- a/Web.HtmlSanitizer/HtmlSanitizer.cs
+++ b/Web.HtmlSanitizer/HtmlSanitizer.cs
@@ -306,6 +306,16 @@ public class HtmlSanitizer : IHtmlSanitizer
 				// Ensure that all attributes are set according to the rule.
 				foreach (KeyValuePair<string, string> setAttribute in rule.SetAttributes.Where(r => !node.Attributes.Contains(r.Key)))
 					node.Attributes.Add(setAttribute.Key, setAttribute.Value);
+
+				// Apply any element checks.
+				foreach (var elementCheck in rule.ElementChecks)
+				{
+					operation = elementCheck.SanitizeElement(node, rule);
+					if (!ApplyNodeOperation(node, operation))
+					{
+						return;
+					}
+				}
 			}
 
 			// Finally process any child nodes recursively.

--- a/Web.HtmlSanitizer/HtmlSanitizerFluentHelper.cs
+++ b/Web.HtmlSanitizer/HtmlSanitizerFluentHelper.cs
@@ -144,6 +144,18 @@ public static class HtmlSanitizerFluentHelper
 	}
 
 	/// <summary>
+	/// Specifies the passed element sanitizer is to be applied to this tag.
+	/// </summary>
+	/// <param name="rule"></param>
+	/// <param name="elementSanitizer"></param>
+	/// <returns></returns>
+	public static HtmlSanitizerTagRule Sanitize(this HtmlSanitizerTagRule rule, IHtmlElementSanitizer elementSanitizer)
+	{
+		rule.ElementChecks.Add(elementSanitizer);
+		return rule;
+	}
+
+	/// <summary>
 	/// Specifies that the value of any attribute with the given name is to be set to the specified value.
 	/// </summary>
 	/// <param name="rule"></param>

--- a/Web.HtmlSanitizer/HtmlSanitizerTagRule.cs
+++ b/Web.HtmlSanitizer/HtmlSanitizerTagRule.cs
@@ -19,6 +19,7 @@ public class HtmlSanitizerTagRule
 		SetAttributes = new Dictionary<string, string>();
 		CheckAttributes = new Dictionary<string, HtmlSanitizerCheckType>();
 		AttributeChecks = new Dictionary<string, IHtmlAttributeSanitizer>();
+		ElementChecks = new List<IHtmlElementSanitizer>();
 		NoAttributesOperation = SanitizerOperation.DoNothing;
 	}
 
@@ -26,6 +27,11 @@ public class HtmlSanitizerTagRule
 	/// Sets which sanitizers to perform on which attributes. Attribute name as key, sanitizer instance as value.
 	/// </summary>
 	public IDictionary<string, IHtmlAttributeSanitizer> AttributeChecks { get; protected set; }
+
+	/// <summary>
+	/// Sets which sanitizers to perform on the whole element.
+	/// </summary>
+	public IList<IHtmlElementSanitizer> ElementChecks { get; protected set; }
 
     /// <summary>
     /// Sets which checks to perform on which attributes. Attribute name as key, check type as value.

--- a/Web.HtmlSanitizer/IHtmlElementSanitizer.cs
+++ b/Web.HtmlSanitizer/IHtmlElementSanitizer.cs
@@ -1,0 +1,14 @@
+﻿using HtmlAgilityPack;
+
+namespace Vereyon.Web;
+
+public interface IHtmlElementSanitizer
+{
+	/// <summary>
+	/// Checks the passed element.
+	/// </summary>
+	/// <param name="element"></param>
+	/// <param name="tagRule"></param>
+	/// <returns></returns>
+	SanitizerOperation SanitizeElement(HtmlNode element, HtmlSanitizerTagRule tagRule);
+}


### PR DESCRIPTION
This adds element-level sanitizers. The intent is to have an extension point where one can inject custom logic that applies to the whole element.

One use-case is to add a wrapper around specific elements, but any situation where one would want to look at the element as a whole, and perhaps its descendants as well, is enabled by this feature.

The way I've implemented it is by defining a new interface, `IHtmlElementSanitizer` that is similar to `IHtmlAttributeSanitizer` but takes an HtmlNode instead of an HtmlAttribute. It is named IHtmlElementSanitizer and not IHtmlNodeSanitizer because the interface applies only to elements, not other HTML nodes.
Any number of instances of that interface can be registered on the tag rule to provide the desired effect.

I have added a test that checks the use-case that I had in mind, wrapping specific elements into others, and another one that removes elements based on their content.