### PR TITLE
Bump HtmlAgilityPack version to 1.11 to avoid incomplete HTML being returned

### DIFF
--- a/Web.HtmlSanitizer.Tests/ElementSanitizationTests.cs
+++ b/Web.HtmlSanitizer.Tests/ElementSanitizationTests.cs
@@ -57,5 +57,23 @@ namespace Vereyon.Web
                 return sanitize(element);
             }
         }
+
+        /// <summary>
+        /// This test aims to cover a bug in HTML Agility Pack which was fixed in version 1.11.
+        /// Versions before it would result in malformed HTML being returned.
+        /// </summary>
+        [Fact]
+        public void IncompleteTagHandling()
+        {
+
+            var sanitizer = HtmlSanitizer.SimpleHtml5Sanitizer();
+            sanitizer.Tag("svg");
+            sanitizer.Tag("p");
+
+            var input = @"<p><svg />";
+            var expected = "<p><svg></svg></p>";
+            var output = sanitizer.Sanitize(input);
+            Assert.Equal(expected, output);
+        }
     }
 }

--- a/Web.HtmlSanitizer.Tests/Web.HtmlSanitizer.Tests.csproj
+++ b/Web.HtmlSanitizer.Tests/Web.HtmlSanitizer.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.7.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Bumping HtmlAgilityPack to version 1.11 or higher resolves #37.